### PR TITLE
Refactor to use Restream Events endpoints

### DIFF
--- a/functions/OnStreamStart.ts
+++ b/functions/OnStreamStart.ts
@@ -210,6 +210,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   //
   if (inprogressEvents.length == 0) {
     console.log("No in-progress events found, sending alert to Teams");
+    var post = new Object();
     post["@type"] = "MessageCard";
     post["@context"] = "http://schema.org/extensions";
     post["themeColor"] = "0076D7";

--- a/functions/OnStreamStart.ts
+++ b/functions/OnStreamStart.ts
@@ -184,14 +184,10 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     });
   }
 
-  inprogressEvents = await inprogressEventsResp.json();
-  console.log(JSON.stringify(inprogressEvents));
-
-  if ((inprogressEvents as ErrorResp).error) {
-    return new Response((inprogressEvents as ErrorResp).error, {
-      status: inprogressEventsResp.status,
-    });
-  }
-
-  return new Response(JSON.stringify(inprogressEvents), { status: 200 });
+  return new Response(JSON.stringify(inprogressEvents), {
+    headers: {
+      "content-type": "application/json",
+    },
+    status: 200
+  });
 };

--- a/functions/RestreamChannels.ts
+++ b/functions/RestreamChannels.ts
@@ -1,24 +1,4 @@
-interface Platform {
-  id: number;
-  name: string;
-  url: string;
-  image: any;
-}
-
-interface Channel {
-  id: number;
-  streamingPlatformId: number;
-  displayName: string;
-  enabled: boolean; // Note restream's documentation says this is active, but it's actually enabled
-  url: string;
-  embedUrl: string;
-  identifier: string;
-}
-
-interface ErrorResp {
-  error: string;
-}
-
+import {Channel, Platform, ErrorResp} from "./types";
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   //

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -1,0 +1,40 @@
+interface Platform {
+  id: number;
+  name: string;
+  url: string;
+  image: any;
+}
+
+interface Channel {
+  id: number;
+  streamingPlatformId: number;
+  displayName: string;
+  enabled: boolean; // This may be deprecated with restream's new events system
+  url: string;
+  embedUrl: string;
+  identifier: string;
+}
+
+interface ErrorResp {
+  error: string;
+}
+
+interface Destination {
+  channelId: number;
+  externalUrl: string;
+  streamingPlatformId: number;
+}
+
+interface Event {
+  id: number;
+  status: string;
+  title: string;
+  description: string;
+  coverUrl: string;
+  scheduledFor: number;
+  startedAt: number;
+  finishedAt: number;
+  destinations: Destination[];
+}
+
+export { Platform, Channel, Destination, ErrorResp, Event };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "RestreamGetURL",
+  "name": "Hope-Functions",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Restream now treats all streams as events, which causes some disconnect between the old `channels` API endpoints. This change migrates to using the `events` API endpoints as the primary source of information and supplementing that as needed with information from other endpoints. Additionally, there is now better handling for edge/error cases where restream might not be receiving the appropriate data or if restream doesn't have any channels enabled.